### PR TITLE
[fix] Avoid AttributeError and IndexError in checking title variable

### DIFF
--- a/papers3.py
+++ b/papers3.py
@@ -38,7 +38,7 @@ def read_papers_entries():
     for entry in result:
         title = entry['title']
         if title == applescript.kMissingValue:
-                title = ''
+            title = ''
         if len(title) > 1 and title[0] == '{' and title[-1] == '}':
             title = title[1:-1]
         entry['title'] = title

--- a/papers3.py
+++ b/papers3.py
@@ -37,7 +37,9 @@ def read_papers_entries():
     entries = []
     for entry in result:
         title = entry['title']
-        if title[0] == '{' and title[-1] == '}':
+        if not isinstance(title, unicode):
+            title = u""
+        if len(title) > 1 and title[0] == '{' and title[-1] == '}':
             title = title[1:-1]
         entry['title'] = title
 

--- a/papers3.py
+++ b/papers3.py
@@ -37,8 +37,8 @@ def read_papers_entries():
     entries = []
     for entry in result:
         title = entry['title']
-        if not isinstance(title, unicode):
-            title = u""
+        if title == applescript.kMissingValue:
+                title = ''
         if len(title) > 1 and title[0] == '{' and title[-1] == '}':
             title = title[1:-1]
         entry['title'] = title


### PR DESCRIPTION
Following errors occur:
- if a title have never been set in Papers3
`AttributeError: AEType instance has no attribute '__getitem__'`
 - or if a title length less than 2
`IndexError: string index out of range`.

To avoid these errors, some conditions are added.